### PR TITLE
Forget to return in setup_iv()

### DIFF
--- a/pproxy/cipher.py
+++ b/pproxy/cipher.py
@@ -43,6 +43,7 @@ class AEADCipher(BaseCipher):
         self._buffer = bytearray()
         self._declen = None
         self.setup()
+        return self
     @property
     def nonce(self):
         ret = self._nonce.to_bytes(self.NONCE_LENGTH, 'little')


### PR DESCRIPTION
Exception:
'NoneType' object has no attribute 'iv' from 127.0.0.1